### PR TITLE
Makes the create ready for wasm builds (non-weighted delaunay only)

### DIFF
--- a/.github/workflows/rita.yml
+++ b/.github/workflows/rita.yml
@@ -17,8 +17,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
 
-      - name: Test
+      - name: Test (geogram predicates)
         run: cargo test -p rita --features logging
+      - name: Test (robust predicates)
+        run: cargo test -p rita --no-default-features --features "std,wasm"
 
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rita.yml
+++ b/.github/workflows/rita.yml
@@ -33,5 +33,5 @@ jobs:
         continue-on-error: true
       - name: clippy std
         run: cargo clippy -p rita
-      - name: clippy no-std
-        run: cargo clippy -p rita --no-default-features
+      - name: clippy wasm
+        run: cargo clippy -p rita --no-default-features --features "std,wasm"

--- a/.github/workflows/rita.yml
+++ b/.github/workflows/rita.yml
@@ -29,9 +29,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: fmt
-        run: cargo fmt --check -p rita --all-features
+        run: cargo fmt --check -p rita
         continue-on-error: true
       - name: clippy std
-        run: cargo clippy -p rita --all-features
+        run: cargo clippy -p rita
       - name: clippy no-std
         run: cargo clippy -p rita --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3073,6 +3073,7 @@ dependencies = [
  "nalgebra",
  "rayon",
  "rita_test_utils",
+ "robust",
 ]
 
 [[package]]
@@ -3101,6 +3102,12 @@ dependencies = [
  "rand 0.9.1",
  "rand_distr",
 ]
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "ron"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ There might be duplicate and unnecessarily complex code.
 ## Robustness
 Robustness is achieved through [geogram_predicates](https://github.com/glenndittmann/geogram_predicates), which itself uses [cxx](https://github.com/dtolnay/cxx) to make the geometric predicates from [geogram](https://github.com/BrunoLevy/geogram) available in `rust`.
 
+## Wasm
+In order to have an easy wasm compilable target it is necessary to have a rust only version of this crate. The usage of `geogram_predicates` makes this difficult as its an ffi to the `geogram` c++ library.
+The workaround is to have an abstraction layer over the geometric predicates. For normal usage the `geogram_predicates` will be used.
+When activating `wasm` the fallback rust-only predicates will be used. The downside of these is that they do not support lifted orientation test, i.e. we can not compute weighted Delaunay triangulations.
+For the majority of the use cases however this is fine, and maybe `robust` can be extended in the future to support the weighted predicates as well.
+
+## Testing
+To make sure both predicate libraries produce the same results tests can be run for both features.
+
+### Testing with geogram_predicates
+`cargo test -p rita --features logging`
+
+### Testing with robust
+`cargo test -p rita --no-default-features --features "std,wasm"`
+
 ## Base implementation
 There is decent preliminary work done in the rust eco-system by [Bastien Durix](https://scholar.google.fr/citations?user=Crc4sdsAAAAJ&hl=fr) in the crate [simple_delaunay_lib](https://github.com/Ibujah/simple_delaunay_lib).
 

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -21,7 +21,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-geogram_predicates = "0.2.1"
+geogram_predicates = { version = "0.2.1", optional = true }
 log = { version = "0.4", optional = true }
 nalgebra = { version = "0.33", features = [
     "libm",
@@ -29,14 +29,18 @@ nalgebra = { version = "0.33", features = [
     "matrixmultiply",
 ], default-features = false }
 rayon = "1.10"
+robust = { version = "1.2", optional = true }
 arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 rita_test_utils = { path = "../rita_test_utils" }
 
 [features]
-default = ["std"]
+default = ["std", "geogram"]
 std = ["anyhow/std", "nalgebra/std"]
+geogram = ["dep:geogram_predicates"]
+# wasm: use pure-Rust robust predicates (no weighted Delaunay). For wasm32 build with: --no-default-features --features "std,wasm"
+wasm = ["dep:robust"]
 timing = ["std"]
 logging = ["dep:log"]
 log_timing = ["logging", "timing"]

--- a/rita/src/lib.rs
+++ b/rita/src/lib.rs
@@ -4,6 +4,8 @@
 //!
 //! ## Features
 //! - `std` (default) - enables anyhow and nalgebra's std features
+//! - `geogram` (default) - uses [geogram_predicates] for robust predicates (FFI to C++); supports weighted Delaunay
+//! - `wasm` - uses pure-Rust [robust] predicates for wasm32 builds; **no weighted Delaunay** (use `weights: None`). Build with: `--no-default-features --features "std,wasm"`
 //! - `timing` - enables timing of function run time, this requires std
 //! - `logging` - uses `log` to record errors and warnings, along with some extra information
 //! - `log_timing` - enables logging and timing, to record timing info
@@ -19,6 +21,7 @@ pub use tetrahedralization::Tetrahedralization;
 pub use triangulation::Triangulation;
 
 pub mod node;
+mod predicates;
 mod tetds;
 pub mod tetrahedralization;
 pub mod triangulation;

--- a/rita/src/predicates.rs
+++ b/rita/src/predicates.rs
@@ -1,0 +1,216 @@
+//! Geometric predicates abstraction.
+//!
+//! With feature `geogram` (default): uses [geogram_predicates] (FFI to C++ geogram) — supports
+//! weighted 2D/3D (power circle/sphere via `orient_*lifted_SOS`).
+//!
+//! With feature `wasm`: uses pure-Rust [robust] — unweighted only; weighted APIs are unavailable.
+
+#![allow(dead_code)]
+#![allow(non_snake_case)] // match geogram_predicates API (in_sphere_3d_SOS, orient_*lifted_SOS)
+
+use crate::utils::types::{Vertex2, Vertex3};
+
+// Exactly one of geogram or wasm must be enabled.
+#[cfg(not(any(feature = "geogram", feature = "wasm")))]
+compile_error!(
+    "Exactly one of features 'geogram' or 'wasm' must be enabled. Use default (geogram) or --no-default-features --features 'std,wasm' for WASM."
+);
+
+#[cfg(all(feature = "geogram", feature = "wasm"))]
+compile_error!(
+    "Features 'geogram' and 'wasm' are mutually exclusive. For WASM use --no-default-features --features 'std,wasm'."
+);
+
+/// Normalize predicate result to sign: -1.0, 0.0, or 1.0 so that `==` compares signs.
+#[inline]
+fn sign_f64(x: f64) -> f64 {
+    if x > 0.0 {
+        1.0
+    } else if x < 0.0 {
+        -1.0
+    } else {
+        0.0
+    }
+}
+
+#[cfg(all(feature = "geogram", not(feature = "wasm")))]
+mod imp {
+    use super::*;
+    use geogram_predicates as gp;
+
+    #[inline]
+    pub fn orient_2d(a: &Vertex2, b: &Vertex2, c: &Vertex2) -> f64 {
+        let r = gp::orient_2d(a, b, c);
+        if r > 0i16 {
+            1.0
+        } else if r < 0i16 {
+            -1.0
+        } else {
+            0.0
+        }
+    }
+
+    #[inline]
+    pub fn orient_3d(a: &Vertex3, b: &Vertex3, c: &Vertex3, d: &Vertex3) -> f64 {
+        let r = gp::orient_3d(a, b, c, d);
+        if r > 0i16 {
+            1.0
+        } else if r < 0i16 {
+            -1.0
+        } else {
+            0.0
+        }
+    }
+
+    #[inline]
+    pub fn in_sphere_3d_SOS(
+        a: &Vertex3,
+        b: &Vertex3,
+        c: &Vertex3,
+        d: &Vertex3,
+        p: &Vertex3,
+    ) -> f64 {
+        let r = gp::in_sphere_3d_SOS(a, b, c, d, p);
+        if r > 0i16 {
+            1.0
+        } else if r < 0i16 {
+            -1.0
+        } else {
+            0.0
+        }
+    }
+
+    #[inline]
+    pub fn orient_2dlifted_SOS(
+        a: &Vertex2,
+        b: &Vertex2,
+        c: &Vertex2,
+        p: &Vertex2,
+        h_a: f64,
+        h_b: f64,
+        h_c: f64,
+        h_p: f64,
+    ) -> f64 {
+        let r = gp::orient_2dlifted_SOS(a, b, c, p, h_a, h_b, h_c, h_p);
+        if r > 0i16 {
+            1.0
+        } else if r < 0i16 {
+            -1.0
+        } else {
+            0.0
+        }
+    }
+
+    #[inline]
+    pub fn orient_3dlifted_SOS(
+        a: &Vertex3,
+        b: &Vertex3,
+        c: &Vertex3,
+        d: &Vertex3,
+        p: &Vertex3,
+        h_a: f64,
+        h_b: f64,
+        h_c: f64,
+        h_d: f64,
+        h_p: f64,
+    ) -> f64 {
+        let r = gp::orient_3dlifted_SOS(a, b, c, d, p, h_a, h_b, h_c, h_d, h_p);
+        if r > 0i16 {
+            1.0
+        } else if r < 0i16 {
+            -1.0
+        } else {
+            0.0
+        }
+    }
+}
+
+#[cfg(all(feature = "wasm", not(feature = "geogram")))]
+mod imp {
+    use super::*;
+    use robust::{Coord, Coord3D, incircle, insphere, orient2d, orient3d};
+
+    #[inline]
+    fn coord2(p: &Vertex2) -> Coord<f64> {
+        Coord { x: p[0], y: p[1] }
+    }
+
+    #[inline]
+    fn coord3(p: &Vertex3) -> Coord3D<f64> {
+        Coord3D {
+            x: p[0],
+            y: p[1],
+            z: p[2],
+        }
+    }
+
+    #[inline]
+    pub fn orient_2d(a: &Vertex2, b: &Vertex2, c: &Vertex2) -> f64 {
+        sign_f64(orient2d(coord2(a), coord2(b), coord2(c)))
+    }
+
+    #[inline]
+    pub fn orient_3d(a: &Vertex3, b: &Vertex3, c: &Vertex3, d: &Vertex3) -> f64 {
+        sign_f64(orient3d(coord3(a), coord3(b), coord3(c), coord3(d)))
+    }
+
+    /// Unweighted incircle (power circle with all heights zero). Used when `wasm` feature is on;
+    /// weights are not allowed, so this is equivalent to orient_2dlifted_SOS with all h = 0.
+    #[inline]
+    pub fn orient_2dlifted_SOS(
+        a: &Vertex2,
+        b: &Vertex2,
+        c: &Vertex2,
+        p: &Vertex2,
+        _h_a: f64,
+        _h_b: f64,
+        _h_c: f64,
+        _h_p: f64,
+    ) -> f64 {
+        sign_f64(incircle(coord2(a), coord2(b), coord2(c), coord2(p)))
+    }
+
+    /// Unweighted insphere (same as in_sphere_3d_SOS). Used when `wasm` feature is on.
+    #[inline]
+    pub fn in_sphere_3d_SOS(
+        a: &Vertex3,
+        b: &Vertex3,
+        c: &Vertex3,
+        d: &Vertex3,
+        p: &Vertex3,
+    ) -> f64 {
+        sign_f64(insphere(
+            coord3(a),
+            coord3(b),
+            coord3(c),
+            coord3(d),
+            coord3(p),
+        ))
+    }
+
+    /// Unweighted insphere (power sphere with all heights zero). Used when `wasm` feature is on.
+    #[inline]
+    pub fn orient_3dlifted_SOS(
+        a: &Vertex3,
+        b: &Vertex3,
+        c: &Vertex3,
+        d: &Vertex3,
+        p: &Vertex3,
+        _h_a: f64,
+        _h_b: f64,
+        _h_c: f64,
+        _h_d: f64,
+        _h_p: f64,
+    ) -> f64 {
+        sign_f64(insphere(
+            coord3(a),
+            coord3(b),
+            coord3(c),
+            coord3(d),
+            coord3(p),
+        ))
+    }
+}
+
+// Re-export so call sites can use crate::predicates::orient_2d etc.
+pub use imp::{in_sphere_3d_SOS, orient_2d, orient_2dlifted_SOS, orient_3d, orient_3dlifted_SOS};

--- a/rita/src/predicates.rs
+++ b/rita/src/predicates.rs
@@ -81,6 +81,7 @@ mod imp {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn orient_2dlifted_SOS(
         a: &Vertex2,
         b: &Vertex2,
@@ -102,6 +103,7 @@ mod imp {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn orient_3dlifted_SOS(
         a: &Vertex3,
         b: &Vertex3,

--- a/rita/src/predicates.rs
+++ b/rita/src/predicates.rs
@@ -133,12 +133,12 @@ mod imp {
     use robust::{Coord, Coord3D, incircle, insphere, orient2d, orient3d};
 
     #[inline]
-    fn coord2(p: &Vertex2) -> Coord<f64> {
+    const fn coord2(p: &Vertex2) -> Coord<f64> {
         Coord { x: p[0], y: p[1] }
     }
 
     #[inline]
-    fn coord3(p: &Vertex3) -> Coord3D<f64> {
+    const fn coord3(p: &Vertex3) -> Coord3D<f64> {
         Coord3D {
             x: p[0],
             y: p[1],
@@ -159,6 +159,7 @@ mod imp {
     /// Unweighted incircle (power circle with all heights zero). Used when `wasm` feature is on;
     /// weights are not allowed, so this is equivalent to orient_2dlifted_SOS with all h = 0.
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn orient_2dlifted_SOS(
         a: &Vertex2,
         b: &Vertex2,
@@ -192,6 +193,7 @@ mod imp {
 
     /// Unweighted insphere (power sphere with all heights zero). Used when `wasm` feature is on.
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn orient_3dlifted_SOS(
         a: &Vertex3,
         b: &Vertex3,

--- a/rita/src/tetds/tet_data_structure.rs
+++ b/rita/src/tetds/tet_data_structure.rs
@@ -96,7 +96,7 @@ impl TetDataStructure {
         }
     }
 
-    const fn half_triangle(&self, ind_halftriangle: usize) -> HalfTriIterator {
+    const fn half_triangle(&self, ind_halftriangle: usize) -> HalfTriIterator<'_> {
         // TODO: remove this, this is just HalfTriIterator::new(self, ind_halftriangle, ind_halfedge)
         HalfTriIterator {
             tds: self,
@@ -105,7 +105,7 @@ impl TetDataStructure {
     }
 
     /// Gets halfedge iterator from index
-    pub fn get_half_tri(&self, half_tri_idx: usize) -> HowResult<HalfTriIterator> {
+    pub fn get_half_tri(&self, half_tri_idx: usize) -> HowResult<HalfTriIterator<'_>> {
         if half_tri_idx < self.half_tri_opposite.len() {
             HowOk(self.half_triangle(half_tri_idx))
         } else {
@@ -134,7 +134,7 @@ impl TetDataStructure {
         num_casual_tets
     }
 
-    const fn tet(&self, ind_tetrahedron: usize) -> TetIterator {
+    const fn tet(&self, ind_tetrahedron: usize) -> TetIterator<'_> {
         // TODO: remove this, this is just TetIterator::new(self, ind_halftriangle, ind_halfedge)
         TetIterator {
             tds: self,
@@ -143,7 +143,7 @@ impl TetDataStructure {
     }
 
     /// Gets tetrahedron iterator from index
-    pub fn get_tet(&self, ind_tetrahedron: usize) -> HowResult<TetIterator> {
+    pub fn get_tet(&self, ind_tetrahedron: usize) -> HowResult<TetIterator<'_>> {
         if ind_tetrahedron < self.num_tets {
             HowOk(self.tet(ind_tetrahedron))
         } else {
@@ -161,7 +161,7 @@ impl TetDataStructure {
         &self,
         node0: &VertexNode,
         node1: &VertexNode,
-    ) -> Vec<HedgeIterator> {
+    ) -> Vec<HedgeIterator<'_>> {
         let mut hedges = Vec::new();
 
         for i in 0..self.num_tets() {
@@ -204,7 +204,7 @@ impl TetDataStructure {
         node1: &VertexNode,
         node2: &VertexNode,
         node3: &VertexNode,
-    ) -> Option<HalfTriIterator> {
+    ) -> Option<HalfTriIterator<'_>> {
         for i in 0..self.num_tets {
             let first_node = i << 2;
             let mut sub_ind_v0 = 4;
@@ -247,7 +247,7 @@ impl TetDataStructure {
     }
 
     /// Gets tetrahedra containing a specific node
-    pub fn get_tet_containing(&self, node: &VertexNode) -> Vec<TetIterator> {
+    pub fn get_tet_containing(&self, node: &VertexNode) -> Vec<TetIterator<'_>> {
         let mut tets = Vec::new();
 
         for i in 0..self.num_tets {
@@ -565,7 +565,7 @@ impl TetDataStructure {
     }
 
     /// Inserts a first tetrahedron in the structure
-    pub fn insert_first_tet(&mut self, nodes: [usize; 4]) -> HowResult<[TetIterator; 4]> {
+    pub fn insert_first_tet(&mut self, nodes: [usize; 4]) -> HowResult<[TetIterator<'_>; 4]> {
         if self.num_tets != 0 {
             return Err(anyhow::Error::msg("Already tetrahedra in simplicial"));
         }

--- a/rita/src/tetrahedralization.rs
+++ b/rita/src/tetrahedralization.rs
@@ -347,8 +347,8 @@ impl Tetrahedralization {
         {
             let p = self.vertices[v_idx];
 
-            let h_p = if self.epsilon.is_some() {
-                self.height(v_idx) + self.epsilon.unwrap()
+            let h_p = if let Some(epsilon) = self.epsilon {
+                self.height(v_idx) + epsilon
             } else {
                 panic!("Epsilon not set!");
             };

--- a/rita/src/tetrahedralization.rs
+++ b/rita/src/tetrahedralization.rs
@@ -1,6 +1,6 @@
 use alloc::{vec, vec::Vec};
-use core::cmp;
 
+use crate::predicates;
 use crate::{
     VertexNode,
     tetds::{half_tri_iterator::HalfTriIterator, tet_data_structure::TetDataStructure},
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 use anyhow::Result as HowResult;
-use geogram_predicates as gp;
 #[cfg(feature = "logging")]
 use log::error;
 use rayon::prelude::*;
@@ -40,11 +39,9 @@ pub enum ExtendedTetrahedron {
 ///     [1.5, 1.5, 3.0],
 ///     [3.0, 1.0, 4.0],
 /// ];
-/// let weights = vec![0.2, 0.3, 0.55, 0.5, 0.6, 0.4, 0.65, 0.7, 0.85, 0.35];
 ///
 /// let mut tetrahedralization = Tetrahedralization::new(None); // specify epsilon here
-/// let result = tetrahedralization.insert_vertices(&vertices, Some(weights), true);  // last parameter toggles spatial sorting
-/// println!("{:?}", result);
+/// let result = tetrahedralization.insert_vertices(&vertices, None, true);  // None = unweighted; use Some(weights) with geogram for weighted
 /// assert_eq!(tetrahedralization.par_is_regular(false), 1.0);
 /// ```
 #[derive(Debug)]
@@ -297,15 +294,15 @@ impl Tetrahedralization {
         let in_sphere = match ext_tet {
             // TODO: why do we need to invert gp's in sphere, compared to robust's, they should have the same signs for the same cases
             ExtendedTetrahedron::Tetrahedron([a, b, c, d]) => {
-                -gp::in_sphere_3d_SOS(&a, &b, &c, &d, &p)
+                -predicates::in_sphere_3d_SOS(&a, &b, &c, &d, &p)
             }
-            ExtendedTetrahedron::Triangle([a, b, c]) => -gp::orient_3d(&a, &b, &c, &p),
+            ExtendedTetrahedron::Triangle([a, b, c]) => -predicates::orient_3d(&a, &b, &c, &p),
         };
 
         if strict {
-            Ok(in_sphere > 0)
+            Ok(in_sphere > 0.0)
         } else {
-            Ok(in_sphere >= 0)
+            Ok(in_sphere >= 0.0)
         }
     }
 
@@ -324,46 +321,58 @@ impl Tetrahedralization {
                     .nodes()
                     .map(|n| self.height(n.idx().unwrap()));
 
-                gp::orient_3dlifted_SOS(&a, &b, &c, &d, &p, h_a, h_b, h_c, h_d, h_p)
+                predicates::orient_3dlifted_SOS(&a, &b, &c, &d, &p, h_a, h_b, h_c, h_d, h_p)
             }
             // if the triangle is a line segment, then the power sphere is a sphere with infinite radius and we can use a orientation test
-            ExtendedTetrahedron::Triangle([a, b, c]) => -gp::orient_3d(&a, &b, &c, &p),
+            ExtendedTetrahedron::Triangle([a, b, c]) => -predicates::orient_3d(&a, &b, &c, &p),
         };
 
         if strict {
-            Ok(in_sphere > 0)
+            Ok(in_sphere > 0.0)
         } else {
-            Ok(in_sphere >= 0)
+            Ok(in_sphere >= 0.0)
         }
     }
 
     fn is_v_in_eps_powersphere(&self, v_idx: usize, tet_idx: usize) -> HowResult<bool> {
-        let p = self.vertices[v_idx];
+        #[cfg(feature = "wasm")]
+        let _ = (v_idx, tet_idx);
 
-        let h_p = if self.epsilon.is_some() {
-            self.height(v_idx) + self.epsilon.unwrap()
-        } else {
-            panic!("Epsilon not set!");
-        };
+        #[cfg(feature = "wasm")]
+        return Err(anyhow::Error::msg(
+            "Epsilon power sphere is not supported in wasm (robust predicates are unweighted).",
+        ));
 
-        let ext_tet = self.get_tet_as_extended(tet_idx)?;
+        #[cfg(not(feature = "wasm"))]
+        {
+            let p = self.vertices[v_idx];
 
-        match ext_tet {
-            ExtendedTetrahedron::Tetrahedron([a, b, c, d]) => {
-                let [h_a, h_b, h_c, h_d] = self
-                    .tds()
-                    .get_tet(tet_idx)?
-                    .nodes()
-                    .map(|n| self.height(n.idx().unwrap()));
+            let h_p = if self.epsilon.is_some() {
+                self.height(v_idx) + self.epsilon.unwrap()
+            } else {
+                panic!("Epsilon not set!");
+            };
 
-                let in_eps_circle =
-                    gp::orient_3dlifted_SOS(&a, &b, &c, &d, &p, h_a, h_b, h_c, h_d, h_p);
+            let ext_tet = self.get_tet_as_extended(tet_idx)?;
 
-                Ok(in_eps_circle > 0)
+            match ext_tet {
+                ExtendedTetrahedron::Tetrahedron([a, b, c, d]) => {
+                    let [h_a, h_b, h_c, h_d] = self
+                        .tds()
+                        .get_tet(tet_idx)?
+                        .nodes()
+                        .map(|n| self.height(n.idx().unwrap()));
+
+                    let in_eps_circle = predicates::orient_3dlifted_SOS(
+                        &a, &b, &c, &d, &p, h_a, h_b, h_c, h_d, h_p,
+                    );
+
+                    Ok(in_eps_circle > 0.0)
+                }
+                ExtendedTetrahedron::Triangle(_) => Err(anyhow::Error::msg(
+                    "Epsilon power circle test not allowed for conceptual triangles yet!",
+                )),
             }
-            ExtendedTetrahedron::Triangle(_) => Err(anyhow::Error::msg(
-                "Epsilon power circle test not allowed for conceptual triangles yet!",
-            )),
         }
     }
 
@@ -372,7 +381,7 @@ impl Tetrahedralization {
 
         // TODO: completely cover this with match
         let is_flat = if let ExtendedTetrahedron::Tetrahedron(tri) = ext_tri {
-            gp::orient_3d(&tri[0], &tri[1], &tri[2], &tri[3]) == 0
+            predicates::orient_3d(&tri[0], &tri[1], &tri[2], &tri[3]) == 0.0
         } else {
             false
         };
@@ -398,13 +407,13 @@ impl Tetrahedralization {
                 let v1 = self.vertices[v_idx1];
                 let v2 = self.vertices[v_idx2];
 
-                let orientation = -gp::orient_3d(&v0, &v1, &v2, v);
+                let orientation = -predicates::orient_3d(&v0, &v1, &v2, v);
 
                 if tri.tet().is_conceptual() {
-                    if orientation <= 0 {
+                    if orientation <= 0.0 {
                         return Some(tri);
                     }
-                } else if orientation < 0 {
+                } else if orientation < 0.0 {
                     return Some(tri);
                 }
             }
@@ -574,20 +583,16 @@ impl Tetrahedralization {
                 if let Some(idx3) = idxs_to_insert.pop() {
                     let v3 = self.vertices[idx3];
 
-                    let orientation = -gp::orient_3d(&v0, &v1, &v2, &v3);
+                    let orientation = -predicates::orient_3d(&v0, &v1, &v2, &v3);
 
-                    match orientation.cmp(&0) {
-                        cmp::Ordering::Greater => {
-                            self.tds.insert_first_tet([idx0, idx1, idx2, idx3])?
-                        }
-                        cmp::Ordering::Less => {
-                            self.tds.insert_first_tet([idx0, idx2, idx1, idx3])?
-                        }
-                        cmp::Ordering::Equal => {
-                            aligned.push(idx3);
-                            continue;
-                        }
-                    };
+                    if orientation > 0.0 {
+                        self.tds.insert_first_tet([idx0, idx1, idx2, idx3])?;
+                    } else if orientation < 0.0 {
+                        self.tds.insert_first_tet([idx0, idx2, idx1, idx3])?;
+                    } else {
+                        aligned.push(idx3);
+                        continue;
+                    }
 
                     self.used_vertices.append(&mut vec![idx0, idx1, idx2, idx3]);
                 } else {
@@ -645,6 +650,13 @@ impl Tetrahedralization {
         weights: Option<Vec<f64>>,
         spatial_sorting: bool,
     ) -> HowResult<()> {
+        #[cfg(feature = "wasm")]
+        if weights.is_some() {
+            return Err(anyhow::Error::msg(
+                "Weighted Delaunay is not supported in wasm (robust predicates are unweighted). Use weights: None.",
+            ));
+        }
+
         let mut idxs_to_insert = Vec::with_capacity(vertices.len());
 
         for &v in vertices {
@@ -836,13 +848,15 @@ impl Tetrahedralization {
                             .nodes()
                             .map(|n| self.height(n.idx().unwrap()));
 
-                        gp::orient_3dlifted_SOS(&a, &b, &c, &d, v, h_a, h_b, h_c, h_d, h_v)
+                        predicates::orient_3dlifted_SOS(&a, &b, &c, &d, v, h_a, h_b, h_c, h_d, h_v)
                     }
                     // if the triangle is a line segment, then the power sphere is a sphere with infinite radius and we can use a orientation test
-                    ExtendedTetrahedron::Triangle([a, b, c]) => -gp::orient_3d(&a, &b, &c, v),
+                    ExtendedTetrahedron::Triangle([a, b, c]) => {
+                        -predicates::orient_3d(&a, &b, &c, v)
+                    }
                 };
 
-                if in_sphere > 0 {
+                if in_sphere > 0.0 {
                     regular = false;
                     num_violated_tets += 1;
                     break; // each triangle can be violated once
@@ -889,14 +903,11 @@ impl core::fmt::Display for Tetrahedralization {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "logging"))]
 mod pre_test {
-    #[cfg(not(feature = "logging"))]
     #[test]
     fn logging_enabled() {
-        panic!(
-            "\x1b[1;31;7m tests must be run with logging enabled, try `--features logging` \x1b[0m"
-        )
+        // When logging is enabled, this test passes
     }
 }
 

--- a/rita/src/triangulation.rs
+++ b/rita/src/triangulation.rs
@@ -333,10 +333,10 @@ impl Triangulation {
 
         let near_to_idx: usize;
 
-        if near_to.is_some() {
-            near_to_idx = near_to.unwrap();
-        } else if self.last_inserted_triangle.is_some() {
-            near_to_idx = self.last_inserted_triangle.unwrap();
+        if let Some(near_to) = near_to {
+            near_to_idx = near_to;
+        } else if let Some(last_inserted_triangle) = self.last_inserted_triangle {
+            near_to_idx = last_inserted_triangle;
         } else {
             near_to_idx = self.tds().num_tris() + self.tds().num_deleted_tris - 1;
         }
@@ -571,8 +571,8 @@ impl Triangulation {
         {
             let p = self.vertices()[v_idx];
 
-            let h_p = if self.epsilon.is_some() {
-                self.height(v_idx) + self.epsilon.unwrap()
+            let h_p = if let Some(epsilon) = self.epsilon {
+                self.height(v_idx) + epsilon
             } else {
                 panic!("Epsilon not set!");
             };
@@ -1123,7 +1123,7 @@ impl Triangulation {
         }
     }
 
-    fn log_time(&self) {
+    const fn log_time(&self) {
         #[cfg(feature = "log_timing")]
         {
             log::debug!("-------------------------------------------");
@@ -1231,8 +1231,8 @@ impl Triangulation {
 
             match idxs == tri_idxs {
                 // if the possible third tri is the tri abc it fills the reflex wedge and we can flip
-                true => return Some(Flip::ThreeToOne((possible_third_tri.idx, d))),
-                false => return None,
+                true => Some(Flip::ThreeToOne((possible_third_tri.idx, d))),
+                false => None,
             }
         } else {
             panic!("No reflex point found, but we should have found one!");

--- a/rita/src/trids/tri_data_structure.rs
+++ b/rita/src/trids/tri_data_structure.rs
@@ -3,7 +3,7 @@ use crate::{VertexNode, utils::types::HedgeIteratorIdx};
 
 use alloc::vec::Vec;
 use anyhow::{Ok as HowOk, Result as HowResult};
-use geogram_predicates as gp;
+use crate::predicates;
 
 const INACTIVE: usize = usize::MAX;
 
@@ -296,13 +296,13 @@ impl TriDataStructure {
         // 2.1 check orientation of the new triangle and swap if necessary
         // TODO Note: we might be able to infer this information faster than with the predicate (e.g. by if else combinations)
         //            but the flip appears not so often, such that it is sufficient for now
-        let orient = gp::orient_2d(
+        let orient = predicates::orient_2d(
             &vertices[starting_node0.idx().unwrap()],
             &vertices[starting_node1.idx().unwrap()],
             &vertices[starting_node2.idx().unwrap()],
         );
 
-        if orient == -1 {
+        if orient < 0.0 {
             // swap second and third edge
             core::mem::swap(&mut starting_node1, &mut starting_node2);
             core::mem::swap(&mut twin_idx1, &mut twin_idx2);

--- a/rita/src/trids/tri_data_structure.rs
+++ b/rita/src/trids/tri_data_structure.rs
@@ -1,9 +1,9 @@
 use super::{hedge_iterator::HedgeIterator, tri_iterator::TriIterator};
 use crate::{VertexNode, utils::types::HedgeIteratorIdx};
 
+use crate::predicates;
 use alloc::vec::Vec;
 use anyhow::{Ok as HowOk, Result as HowResult};
-use crate::predicates;
 
 const INACTIVE: usize = usize::MAX;
 

--- a/rita/src/trids/tri_data_structure.rs
+++ b/rita/src/trids/tri_data_structure.rs
@@ -69,7 +69,7 @@ impl TriDataStructure {
     }
 
     /// Insert an initial triangle into the triangulation.
-    pub fn add_init_tri(&mut self, v_idxs: [usize; 3]) -> HowResult<[TriIterator; 4]> {
+    pub fn add_init_tri(&mut self, v_idxs: [usize; 3]) -> HowResult<[TriIterator<'_>; 4]> {
         if self.num_tris() > 0 {
             return Err(anyhow::Error::msg(
                 "Triangulation already contains triangles!",
@@ -118,7 +118,7 @@ impl TriDataStructure {
         &mut self,
         idx_to_remove: usize,
         v_idx: usize,
-    ) -> HowResult<[TriIterator; 3]> {
+    ) -> HowResult<[TriIterator<'_>; 3]> {
         if idx_to_remove > self.num_tris() + self.num_deleted_tris {
             return Err(anyhow::Error::msg("Triangle index out of bounds!"));
         }
@@ -162,7 +162,7 @@ impl TriDataStructure {
     }
 
     /// Flips an edge that internally connects two triangles to an edge that connects the other two triangles.
-    pub fn flip_2_to_2(&mut self, idx: usize) -> HowResult<[TriIterator; 2]> {
+    pub fn flip_2_to_2(&mut self, idx: usize) -> HowResult<[TriIterator<'_>; 2]> {
         let hedge_twin_idx = self.hedge_twins[idx];
 
         let tri1_idx = idx / 3;
@@ -237,7 +237,7 @@ impl TriDataStructure {
         idxs_to_flip: [usize; 3],
         reflex_node_idx: usize,
         vertices: &[[f64; 2]],
-    ) -> HowResult<TriIterator> {
+    ) -> HowResult<TriIterator<'_>> {
         // Each of the three triangles has one edge that does not contain the reflex node. i.e. is not shared with the other two triangles
         // these edges form the new triangle
         // we will find these edges (compare with the reflex node idx) and also take the edges respective twin hedge idxs
@@ -353,7 +353,7 @@ impl TriDataStructure {
     }
 
     /// Retrieve a half-edge iterator by index.
-    pub fn get_hedge(&self, idx: usize) -> HowResult<HedgeIterator> {
+    pub fn get_hedge(&self, idx: usize) -> HowResult<HedgeIterator<'_>> {
         if idx >= self.hedge_starting_nodes.len() {
             return Err(anyhow::Error::msg("Hedge index out of bounds"));
         }
@@ -362,7 +362,7 @@ impl TriDataStructure {
     }
 
     /// Retrieve a half-tri iterator by index.
-    pub fn get_tri(&self, idx: usize) -> HowResult<TriIterator> {
+    pub fn get_tri(&self, idx: usize) -> HowResult<TriIterator<'_>> {
         if idx >= self.num_tris() + self.num_deleted_tris {
             // - num_deleted_tris because we have to account for the deleted, that basically clog up array indices
             return Err(anyhow::Error::msg("Tri index out of bounds!"));

--- a/rita/src/utils/convexity.rs
+++ b/rita/src/utils/convexity.rs
@@ -1,21 +1,20 @@
 use super::types::Vertex2;
-use core::cmp;
-use geogram_predicates as gp;
+use crate::predicates;
 
 /// Checks if ang(v1--v0, v1--v2) is convex, flat, or concave
 pub(crate) fn is_convex(v0: Vertex2, v1: Vertex2, v2: Vertex2) -> bool {
     // true <-> used to return 1
-    let sign = gp::orient_2d(&v0, &v1, &v2);
+    let sign = predicates::orient_2d(&v0, &v1, &v2);
 
-    match sign.cmp(&0) {
-        cmp::Ordering::Greater => true,
-        cmp::Ordering::Less => false,
-        cmp::Ordering::Equal => {
-            let v1_v0 = [v1[0] - v0[0], v1[1] - v0[1]];
-            let v1_v2 = [v1[0] - v2[0], v1[1] - v2[1]];
-            let dot_prod = v1_v0[0] * v1_v2[0] + v1_v0[1] * v1_v2[1];
+    if sign > 0.0 {
+        true
+    } else if sign < 0.0 {
+        false
+    } else {
+        let v1_v0 = [v1[0] - v0[0], v1[1] - v0[1]];
+        let v1_v2 = [v1[0] - v2[0], v1[1] - v2[1]];
+        let dot_prod = v1_v0[0] * v1_v2[0] + v1_v0[1] * v1_v2[1];
 
-            dot_prod > 0.
-        }
+        dot_prod > 0.
     }
 }


### PR DESCRIPTION
Adds 
- an abstraction layer that either uses `geogram_predicates` or `robust` for geometric predicates
- updates tests to cover both of the above libraries